### PR TITLE
Add Q-learning gridworld example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# dqn-visual-nevigation
+# Q-learning GridWorld Example
+
+This repository implements a minimal reinforcement learning example: an agent learns to navigate a simple 2D grid using Q-learning.
+
+## Files
+
+- `gridworld_env.py` — Custom GridWorld environment.
+- `q_learning_agent.py` — Q-learning algorithm implementation.
+- `train.py` — Script to train the agent and show results.
+
+## Usage
+
+Install `matplotlib` if needed:
+
+```bash
+pip install matplotlib
+```
+
+Run training:
+
+```bash
+python train.py
+```
+
+The script prints progress every 100 episodes, plots the learning curve, and prints the learned policy grid at the end.

--- a/gridworld_env.py
+++ b/gridworld_env.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+class GridWorldEnv:
+    def __init__(self, grid_size=(6, 6), start=(0, 0), goal=(5, 5), obstacles=None):
+        self.grid_size = grid_size
+        self.start = start
+        self.goal = goal
+        self.obstacles = obstacles if obstacles else [(1, 1), (2, 3), (3, 2), (4, 4)]
+        self.action_space = [0, 1, 2, 3]  # Up, Down, Left, Right
+        self.n_actions = 4
+        self.n_states = grid_size[0] * grid_size[1]
+        self.reset()
+
+    def state_to_pos(self, state):
+        return (state // self.grid_size[1], state % self.grid_size[1])
+
+    def pos_to_state(self, pos):
+        return pos[0] * self.grid_size[1] + pos[1]
+
+    def reset(self):
+        self.agent_pos = self.start
+        return self.pos_to_state(self.agent_pos)
+
+    def step(self, action):
+        y, x = self.agent_pos
+        if action == 0:  # Up
+            y = max(0, y - 1)
+        elif action == 1:  # Down
+            y = min(self.grid_size[0] - 1, y + 1)
+        elif action == 2:  # Left
+            x = max(0, x - 1)
+        elif action == 3:  # Right
+            x = min(self.grid_size[1] - 1, x + 1)
+        next_pos = (y, x)
+        reward = -1
+        done = False
+
+        if next_pos in self.obstacles:
+            reward = -10
+            next_pos = self.agent_pos  # stay in place
+        elif next_pos == self.goal:
+            reward = 20
+            done = True
+
+        self.agent_pos = next_pos
+        return self.pos_to_state(self.agent_pos), reward, done, {}
+
+    def render(self):
+        grid = np.full(self.grid_size, ".", dtype=str)
+        for oy, ox in self.obstacles:
+            grid[oy, ox] = "#"
+        gy, gx = self.goal
+        grid[gy, gx] = "G"
+        ay, ax = self.agent_pos
+        grid[ay, ax] = "A"
+        for row in grid:
+            print(" ".join(row))
+        print()

--- a/q_learning_agent.py
+++ b/q_learning_agent.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+class QLearningAgent:
+    def __init__(self, n_states, n_actions, alpha=0.1, gamma=0.99, epsilon=1.0, epsilon_decay=0.995, epsilon_min=0.01):
+        self.n_actions = n_actions
+        self.q_table = np.zeros((n_states, n_actions))
+        self.alpha = alpha
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.epsilon_decay = epsilon_decay
+        self.epsilon_min = epsilon_min
+
+    def select_action(self, state):
+        if np.random.rand() < self.epsilon:
+            return np.random.choice(self.n_actions)
+        return np.argmax(self.q_table[state])
+
+    def update(self, state, action, reward, next_state, done):
+        best_next = np.max(self.q_table[next_state])
+        td_target = reward + self.gamma * best_next * (not done)
+        td_error = td_target - self.q_table[state, action]
+        self.q_table[state, action] += self.alpha * td_error
+
+    def decay_epsilon(self):
+        self.epsilon = max(self.epsilon * self.epsilon_decay, self.epsilon_min)

--- a/train.py
+++ b/train.py
@@ -1,0 +1,68 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from gridworld_env import GridWorldEnv
+from q_learning_agent import QLearningAgent
+
+
+def run_episode(env, agent, train=True, max_steps=100):
+    state = env.reset()
+    total_reward = 0
+    for _ in range(max_steps):
+        action = agent.select_action(state)
+        next_state, reward, done, _ = env.step(action)
+        if train:
+            agent.update(state, action, reward, next_state, done)
+        state = next_state
+        total_reward += reward
+        if done:
+            break
+    if train:
+        agent.decay_epsilon()
+    return total_reward
+
+
+def plot_learning_curve(rewards):
+    plt.plot(rewards)
+    plt.xlabel("Episode")
+    plt.ylabel("Total Reward")
+    plt.title("Learning Curve")
+    plt.grid()
+    plt.show()
+
+
+def plot_policy(env, agent):
+    directions = {0: "↑", 1: "↓", 2: "←", 3: "→"}
+    grid = []
+    for y in range(env.grid_size[0]):
+        row = []
+        for x in range(env.grid_size[1]):
+            state = env.pos_to_state((y, x))
+            if (y, x) in env.obstacles:
+                row.append("#")
+            elif (y, x) == env.goal:
+                row.append("G")
+            else:
+                best_action = np.argmax(agent.q_table[state])
+                row.append(directions[best_action])
+        grid.append(row)
+    for row in grid:
+        print(" ".join(row))
+    print()
+
+
+if __name__ == "__main__":
+    env = GridWorldEnv()
+    agent = QLearningAgent(n_states=env.n_states, n_actions=env.n_actions)
+    n_episodes = 500
+    rewards = []
+    for ep in range(n_episodes):
+        ep_reward = run_episode(env, agent, train=True)
+        rewards.append(ep_reward)
+        if (ep + 1) % 100 == 0:
+            print(f"Episode {ep+1}, Reward: {ep_reward}, Epsilon: {agent.epsilon:.3f}")
+
+    plot_learning_curve(rewards)
+
+    print("Learned Policy:")
+    plot_policy(env, agent)


### PR DESCRIPTION
## Summary
- implement a small custom GridWorld RL environment
- implement a minimal Q-learning agent
- provide a training script and usage instructions

## Testing
- `pip install matplotlib`
- `python train.py`

------
https://chatgpt.com/codex/tasks/task_e_68540c8deeb4832298a508ef9745ac1a