### PR TITLE
Add NumPy-based DQN agent with CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Q-learning GridWorld Example
+# Reinforcement Learning GridWorld Example
 
-This repository implements a minimal reinforcement learning example: an agent learns to navigate a simple 2D grid using Q-learning.
+This repository implements a minimal reinforcement learning playground. An agent learns to navigate a simple 2D grid using either classic Q-learning or a lightweight Deep Q-Network (DQN) built with NumPy.
 
 ## Files
 
 - `gridworld_env.py` — Custom GridWorld environment.
-- `q_learning_agent.py` — Q-learning algorithm implementation.
-- `train.py` — Script to train the agent and show results.
+- `q_learning_agent.py` — Tabular Q-learning implementation.
+- `dqn_agent.py` — DQN agent with a small neural network written in NumPy.
+- `train.py` — Script to train an agent and show results. Choose the algorithm with `--algorithm`.
 
 ## Usage
 
@@ -16,10 +17,10 @@ Install `matplotlib` if needed:
 pip install matplotlib
 ```
 
-Run training:
+Run training (choose `qlearning` or `dqn`):
 
 ```bash
-python train.py
+python train.py --algorithm dqn
 ```
 
 The script prints progress every 100 episodes, plots the learning curve, and prints the learned policy grid at the end.

--- a/dqn_agent.py
+++ b/dqn_agent.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+class DQNAgent:
+    """Simple DQN agent with a two-layer neural network implemented in NumPy."""
+
+    def __init__(self, n_states, n_actions, hidden_size=64, lr=0.01, gamma=0.99,
+                 epsilon=1.0, epsilon_decay=0.995, epsilon_min=0.01):
+        self.n_states = n_states
+        self.n_actions = n_actions
+        self.hidden_size = hidden_size
+        self.lr = lr
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.epsilon_decay = epsilon_decay
+        self.epsilon_min = epsilon_min
+
+        # Xavier initialization
+        limit1 = np.sqrt(6 / (n_states + hidden_size))
+        self.w1 = np.random.uniform(-limit1, limit1, (n_states, hidden_size))
+        self.b1 = np.zeros(hidden_size)
+
+        limit2 = np.sqrt(6 / (hidden_size + n_actions))
+        self.w2 = np.random.uniform(-limit2, limit2, (hidden_size, n_actions))
+        self.b2 = np.zeros(n_actions)
+
+    def _forward(self, state_index):
+        x = np.eye(self.n_states)[state_index]
+        z1 = x @ self.w1 + self.b1
+        a1 = np.maximum(z1, 0)
+        q_values = a1 @ self.w2 + self.b2
+        return q_values, (x, z1, a1)
+
+    @property
+    def q_table(self):
+        states = np.eye(self.n_states)
+        z1 = np.maximum(states @ self.w1 + self.b1, 0)
+        return z1 @ self.w2 + self.b2
+
+    def select_action(self, state):
+        if np.random.rand() < self.epsilon:
+            return np.random.choice(self.n_actions)
+        q_values, _ = self._forward(state)
+        return int(np.argmax(q_values))
+
+    def update(self, state, action, reward, next_state, done):
+        q_values, cache = self._forward(state)
+        next_q_values, _ = self._forward(next_state)
+        target = reward + self.gamma * np.max(next_q_values) * (not done)
+        td_error = q_values[action] - target
+
+        x, z1, a1 = cache
+        grad_z2 = np.zeros_like(q_values)
+        grad_z2[action] = td_error
+        grad_w2 = a1[:, None] @ grad_z2[None, :]
+        grad_b2 = grad_z2
+
+        grad_a1 = grad_z2 @ self.w2.T
+        grad_z1 = grad_a1 * (z1 > 0)
+        grad_w1 = x[:, None] @ grad_z1[None, :]
+        grad_b1 = grad_z1
+
+        self.w2 -= self.lr * grad_w2
+        self.b2 -= self.lr * grad_b2
+        self.w1 -= self.lr * grad_w1
+        self.b1 -= self.lr * grad_b1
+
+    def decay_epsilon(self):
+        self.epsilon = max(self.epsilon * self.epsilon_decay, self.epsilon_min)

--- a/tests/test_dqn_agent.py
+++ b/tests/test_dqn_agent.py
@@ -1,0 +1,37 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import numpy as np
+
+from dqn_agent import DQNAgent
+from gridworld_env import GridWorldEnv
+from train import run_episode
+
+
+def test_select_action_greedy():
+    agent = DQNAgent(n_states=1, n_actions=2, epsilon=0.0)
+    agent.b2 = np.array([1.0, 5.0])  # biases ensure action 1 is best
+    action = agent.select_action(0)
+    assert action == 1
+
+
+def test_epsilon_decay_minimum():
+    agent = DQNAgent(n_states=1, n_actions=1, epsilon=1.0, epsilon_decay=0.5, epsilon_min=0.1)
+    for _ in range(5):
+        agent.decay_epsilon()
+    assert np.isclose(agent.epsilon, 0.1)
+
+
+def test_run_episode_no_training_does_not_update():
+    env = GridWorldEnv(grid_size=(2, 2), start=(0, 0), goal=(0, 1), obstacles=[])
+    agent = DQNAgent(n_states=env.n_states, n_actions=env.n_actions, epsilon=0.0)
+    w1_before = agent.w1.copy()
+    run_episode(env, agent, train=False, max_steps=5)
+    assert np.array_equal(agent.w1, w1_before)
+
+
+def test_update_changes_weights():
+    agent = DQNAgent(n_states=2, n_actions=2, lr=0.1, epsilon=0.0)
+    w1_before = agent.w1.copy()
+    agent.update(0, 1, reward=1, next_state=1, done=False)
+    assert not np.array_equal(agent.w1, w1_before)

--- a/train.py
+++ b/train.py
@@ -1,8 +1,10 @@
+import argparse
 import matplotlib.pyplot as plt
 import numpy as np
 
 from gridworld_env import GridWorldEnv
 from q_learning_agent import QLearningAgent
+from dqn_agent import DQNAgent
 
 
 def run_episode(env, agent, train=True, max_steps=100):
@@ -52,15 +54,28 @@ def plot_policy(env, agent):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--algorithm", choices=["qlearning", "dqn"], default="qlearning",
+                        help="Learning algorithm to use")
+    parser.add_argument("--episodes", type=int, default=500,
+                        help="Number of training episodes")
+    args = parser.parse_args()
+
     env = GridWorldEnv()
-    agent = QLearningAgent(n_states=env.n_states, n_actions=env.n_actions)
-    n_episodes = 500
+
+    if args.algorithm == "dqn":
+        agent = DQNAgent(n_states=env.n_states, n_actions=env.n_actions)
+    else:
+        agent = QLearningAgent(n_states=env.n_states, n_actions=env.n_actions)
+
+    n_episodes = args.episodes
     rewards = []
     for ep in range(n_episodes):
         ep_reward = run_episode(env, agent, train=True)
         rewards.append(ep_reward)
         if (ep + 1) % 100 == 0:
-            print(f"Episode {ep+1}, Reward: {ep_reward}, Epsilon: {agent.epsilon:.3f}")
+            print(
+                f"Episode {ep+1}, Reward: {ep_reward}, Epsilon: {agent.epsilon:.3f}")
 
     plot_learning_curve(rewards)
 


### PR DESCRIPTION
## Summary
- implement a lightweight `DQNAgent` using a small neural network built with NumPy
- extend the training script with `--algorithm` argument to choose Q-learning or DQN
- document the new agent and usage instructions in README
- add tests covering the DQN agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685417f832648322a4a11c199f24562a