### PR TITLE
Add GridWorld visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Run training (choose `qlearning` or `dqn`):
 python train.py --algorithm dqn
 ```
 
-The script prints progress every 100 episodes, plots the learning curve, and prints the learned policy grid at the end.
+The script prints progress every 100 episodes, plots the learning curve, and prints the learned policy grid at the end. Use `--visualize` to see an animated episode demonstrating the learned policy.

--- a/gridworld_env.py
+++ b/gridworld_env.py
@@ -1,4 +1,5 @@
 import numpy as np
+from matplotlib import colors
 
 class GridWorldEnv:
     def __init__(self, grid_size=(6, 6), start=(0, 0), goal=(5, 5), obstacles=None):
@@ -45,14 +46,27 @@ class GridWorldEnv:
         self.agent_pos = next_pos
         return self.pos_to_state(self.agent_pos), reward, done, {}
 
-    def render(self):
-        grid = np.full(self.grid_size, ".", dtype=str)
+    def render(self, ax=None):
+        """Render the grid. If *ax* is provided, draw using matplotlib."""
+        grid = np.zeros(self.grid_size, dtype=int)
         for oy, ox in self.obstacles:
-            grid[oy, ox] = "#"
+            grid[oy, ox] = 1
         gy, gx = self.goal
-        grid[gy, gx] = "G"
-        ay, ax = self.agent_pos
-        grid[ay, ax] = "A"
-        for row in grid:
-            print(" ".join(row))
-        print()
+        grid[gy, gx] = 2
+        ay, axpos = self.agent_pos
+        grid[ay, axpos] = 3
+
+        if ax is None:
+            mapping = {0: ".", 1: "#", 2: "G", 3: "A"}
+            for row in grid:
+                print(" ".join(mapping[cell] for cell in row))
+            print()
+        else:
+            cmap = colors.ListedColormap(["white", "black", "green", "blue"])
+            ax.clear()
+            ax.imshow(grid, cmap=cmap, origin="upper", vmin=0, vmax=3)
+            ax.set_xticks(np.arange(-0.5, self.grid_size[1], 1), minor=True)
+            ax.set_yticks(np.arange(-0.5, self.grid_size[0], 1), minor=True)
+            ax.grid(which="minor", color="gray", linewidth=1)
+            ax.tick_params(left=False, bottom=False,
+                           labelleft=False, labelbottom=False)

--- a/train.py
+++ b/train.py
@@ -53,12 +53,38 @@ def plot_policy(env, agent):
     print()
 
 
+def visualize_episode(env, agent, interval=1, max_steps=100):
+    """Visualize an episode by rendering the grid every *interval* steps."""
+    plt.ion()
+    fig, ax = plt.subplots()
+    state = env.reset()
+    env.render(ax=ax)
+    ax.set_title("Start")
+    plt.pause(0.5)
+
+    for step in range(max_steps):
+        action = agent.select_action(state)
+        next_state, _, done, _ = env.step(action)
+        if step % interval == 0 or done:
+            env.render(ax=ax)
+            ax.set_title(f"Step {step + 1}")
+            plt.pause(0.5)
+        state = next_state
+        if done:
+            break
+
+    plt.ioff()
+    plt.show()
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--algorithm", choices=["qlearning", "dqn"], default="qlearning",
                         help="Learning algorithm to use")
     parser.add_argument("--episodes", type=int, default=500,
                         help="Number of training episodes")
+    parser.add_argument("--visualize", action="store_true",
+                        help="Visualize a demonstration episode after training")
     args = parser.parse_args()
 
     env = GridWorldEnv()
@@ -81,3 +107,6 @@ if __name__ == "__main__":
 
     print("Learned Policy:")
     plot_policy(env, agent)
+
+    if args.visualize:
+        visualize_episode(env, agent)


### PR DESCRIPTION
## Summary
- add simple matplotlib renderer to `GridWorldEnv.render`
- add `visualize_episode` helper in `train.py`
- support `--visualize` option in training script
- document visualization feature in README

## Testing
- `pip install numpy matplotlib --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541a5d336c8322b1d6644cb0069cd7