### PR TITLE
Add dynamic grid features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,23 @@ Install `matplotlib` if needed:
 pip install matplotlib
 ```
 
-Run training (choose `qlearning` or `dqn`):
+Run training (choose `qlearning` or `dqn`). The environment size and layout can
+be customised using command-line options:
+
+```bash
+python train.py --algorithm dqn --grid-size 8 8 --obstacle-density 0.2 \
+    --random-start-goal
+```
+
+The above example trains a DQN agent on an 8x8 grid with 20% of the cells
+randomly blocked and new start/goal locations each episode.
+
+Basic usage without any extras:
 
 ```bash
 python train.py --algorithm dqn
 ```
 
-The script prints progress every 100 episodes, plots the learning curve, and prints the learned policy grid at the end. Use `--visualize` to see an animated episode demonstrating the learned policy.
+The script prints progress every 100 episodes, plots the learning curve, and
+prints the learned policy grid at the end. Use `--visualize` to see an animated
+episode demonstrating the learned policy.

--- a/train.py
+++ b/train.py
@@ -85,9 +85,17 @@ if __name__ == "__main__":
                         help="Number of training episodes")
     parser.add_argument("--visualize", action="store_true",
                         help="Visualize a demonstration episode after training")
+    parser.add_argument("--grid-size", type=int, nargs=2, metavar=("H", "W"),
+                        default=(6, 6), help="Grid dimensions")
+    parser.add_argument("--obstacle-density", type=float, default=0.0,
+                        help="Fraction of cells that are obstacles")
+    parser.add_argument("--random-start-goal", action="store_true",
+                        help="Randomize start and goal each episode")
     args = parser.parse_args()
 
-    env = GridWorldEnv()
+    env = GridWorldEnv(grid_size=tuple(args.grid_size),
+                       obstacle_density=args.obstacle_density,
+                       random_start_goal=args.random_start_goal)
 
     if args.algorithm == "dqn":
         agent = DQNAgent(n_states=env.n_states, n_actions=env.n_actions)


### PR DESCRIPTION
## Summary
- allow random obstacles and start/goal positions in `GridWorldEnv`
- expose grid parameters via new CLI args in `train.py`
- document customisable environment in README

## Testing
- `pip install -q matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854272473b48322a1f091b4e3e20717