### PR TITLE
Enhance training script with advanced visualisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ python train.py --algorithm dqn
 The script prints progress every 100 episodes, plots the learning curve, and
 prints the learned policy grid at the end. Use `--visualize` to see an animated
 episode demonstrating the learned policy.
+
+Additional flags enable richer visualisations:
+
+- `--heatmap` shows a heat map of how often each cell was visited during training.
+- `--q-history` plots how the Q-values for the start state evolve over episodes.
+- `--animate` plays back the final trajectory with a red trace.

--- a/train.py
+++ b/train.py
@@ -7,9 +7,13 @@ from q_learning_agent import QLearningAgent
 from dqn_agent import DQNAgent
 
 
-def run_episode(env, agent, train=True, max_steps=100):
+def run_episode(env, agent, train=True, max_steps=100, record_path=False):
+    """Run a single episode.
+
+    If *record_path* is True, also return the sequence of visited states."""
     state = env.reset()
     total_reward = 0
+    path = [state]
     for _ in range(max_steps):
         action = agent.select_action(state)
         next_state, reward, done, _ = env.step(action)
@@ -17,10 +21,14 @@ def run_episode(env, agent, train=True, max_steps=100):
             agent.update(state, action, reward, next_state, done)
         state = next_state
         total_reward += reward
+        if record_path:
+            path.append(state)
         if done:
             break
     if train:
         agent.decay_epsilon()
+    if record_path:
+        return total_reward, path
     return total_reward
 
 
@@ -77,6 +85,47 @@ def visualize_episode(env, agent, interval=1, max_steps=100):
     plt.show()
 
 
+def plot_visit_heatmap(visit_counts):
+    """Plot a heat map showing how often each cell was visited."""
+    plt.imshow(visit_counts, cmap="hot", origin="upper")
+    plt.title("State Visit Heatmap")
+    plt.colorbar(label="Visits")
+    plt.xticks([])
+    plt.yticks([])
+    plt.show()
+
+
+def plot_q_evolution(q_history, state_index=0):
+    """Plot how Q-values for *state_index* evolve over episodes."""
+    q_arr = np.array([q[state_index] for q in q_history])
+    for action in range(q_arr.shape[1]):
+        plt.plot(q_arr[:, action], label=f"Action {action}")
+    plt.xlabel("Episode")
+    plt.ylabel("Q-value")
+    plt.title(f"Q-value Evolution for state {state_index}")
+    plt.legend()
+    plt.grid()
+    plt.show()
+
+
+def animate_trajectory(env, path, interval=200):
+    """Animate a trajectory given a sequence of states."""
+    plt.ion()
+    fig, ax = plt.subplots()
+    xs, ys = [], []
+    for step, state in enumerate(path):
+        y, x = env.state_to_pos(state)
+        env.agent_pos = (y, x)
+        xs.append(x)
+        ys.append(y)
+        env.render(ax=ax)
+        ax.plot(xs, ys, color="red")
+        ax.set_title(f"Step {step}")
+        plt.pause(interval / 1000.0)
+    plt.ioff()
+    plt.show()
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--algorithm", choices=["qlearning", "dqn"], default="qlearning",
@@ -85,6 +134,12 @@ if __name__ == "__main__":
                         help="Number of training episodes")
     parser.add_argument("--visualize", action="store_true",
                         help="Visualize a demonstration episode after training")
+    parser.add_argument("--heatmap", action="store_true",
+                        help="Show a heat map of visited cells")
+    parser.add_argument("--q-history", action="store_true",
+                        help="Plot Q-value evolution for the start state")
+    parser.add_argument("--animate", action="store_true",
+                        help="Animate the final trajectory using the learned policy")
     parser.add_argument("--grid-size", type=int, nargs=2, metavar=("H", "W"),
                         default=(6, 6), help="Grid dimensions")
     parser.add_argument("--obstacle-density", type=float, default=0.0,
@@ -104,9 +159,21 @@ if __name__ == "__main__":
 
     n_episodes = args.episodes
     rewards = []
+    visit_counts = np.zeros(env.grid_size, dtype=int)
+    q_history = []
     for ep in range(n_episodes):
-        ep_reward = run_episode(env, agent, train=True)
+        record_path = args.heatmap
+        result = run_episode(env, agent, train=True, record_path=record_path)
+        if record_path:
+            ep_reward, path = result
+            for state in path:
+                y, x = env.state_to_pos(state)
+                visit_counts[y, x] += 1
+        else:
+            ep_reward = result
         rewards.append(ep_reward)
+        if args.q_history:
+            q_history.append(agent.q_table.copy())
         if (ep + 1) % 100 == 0:
             print(
                 f"Episode {ep+1}, Reward: {ep_reward}, Epsilon: {agent.epsilon:.3f}")
@@ -116,5 +183,14 @@ if __name__ == "__main__":
     print("Learned Policy:")
     plot_policy(env, agent)
 
+    if args.heatmap:
+        plot_visit_heatmap(visit_counts)
+
+    if args.q_history and q_history:
+        plot_q_evolution(q_history, state_index=env.pos_to_state(env.start))
     if args.visualize:
         visualize_episode(env, agent)
+
+    if args.animate:
+        _, path = run_episode(env, agent, train=False, record_path=True)
+        animate_trajectory(env, path)


### PR DESCRIPTION
## Summary
- allow recording an episode's path in `run_episode`
- add heat map, Q-value plots and trajectory animation helpers
- add CLI flags to use the new visualisations
- document the new options in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685428bce5388322a0c470ab6f52b68c