### PR TITLE
Add evaluation metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ Additional flags enable richer visualisations:
 - `--heatmap` shows a heat map of how often each cell was visited during training.
 - `--q-history` plots how the Q-values for the start state evolve over episodes.
 - `--animate` plays back the final trajectory with a red trace.
+- `--eval-episodes` evaluates the trained agent for the given number of
+  episodes and prints the success rate and average steps.
+
+Example evaluation comparing Q-learning and DQN:
+
+```bash
+python train.py --algorithm qlearning --episodes 300 --eval-episodes 50
+python train.py --algorithm dqn --episodes 300 --eval-episodes 50
+```
+
+The printed metrics make it easy to compare algorithms or different parameter
+settings.

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,18 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import numpy as np
+
+from train import evaluate_agent, run_episode
+from q_learning_agent import QLearningAgent
+from gridworld_env import GridWorldEnv
+
+
+def test_evaluate_agent_success():
+    env = GridWorldEnv(grid_size=(2, 2), start=(0, 0), goal=(0, 1), obstacles=[])
+    agent = QLearningAgent(n_states=env.n_states, n_actions=env.n_actions, epsilon=0.0)
+    # Make agent always move right
+    agent.q_table[:, 3] = 1.0
+    success_rate, avg_steps = evaluate_agent(env, agent, episodes=5, max_steps=2)
+    assert np.isclose(success_rate, 1.0)
+    assert avg_steps <= 2


### PR DESCRIPTION
## Summary
- extend `run_episode` with details option and step counting
- add `evaluate_agent` helper and expose `--eval-episodes` flag
- print evaluation metrics after training
- document usage of evaluation flag and algorithm comparison
- test new evaluation logic

## Testing
- `pip install numpy matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542d9577948322955005489b919567